### PR TITLE
custom delay implementation via edit popup

### DIFF
--- a/CDMSingle.hpp
+++ b/CDMSingle.hpp
@@ -23,7 +23,7 @@
 #pragma comment(lib, "Wininet")
 
 #define MY_PLUGIN_NAME      "CDM Plugin"
-#define MY_PLUGIN_VERSION   "2.2.3"
+#define MY_PLUGIN_VERSION   "2.2.4"
 #define MY_PLUGIN_DEVELOPER "Roger Puig"
 #define MY_PLUGIN_COPYRIGHT "GPL v3"
 #define MY_PLUGIN_VIEW_AVISO  "Euroscope CDM"
@@ -224,6 +224,8 @@ public:
 	void getCADvalues();
 
 	virtual void OnTimer(int Count);
+
+	int FuncBuffer;
 
 protected:
 	Document config;

--- a/Constant.hpp
+++ b/Constant.hpp
@@ -46,6 +46,8 @@ const int TAG_FUNC_EvCTOTtoCTOT = 129;
 const int TAG_FUNC_OPT_EvCTOT = 130;
 const int TAG_FUNC_MODIFYMANCTOT = 131;
 const int TAG_FUNC_TRY_TO_SET_CDT = 132;
+const int TAG_FUNC_CUSTOMTSAT = 133;
+const int TAG_FUNC_EDITFIRSTTSAT = 134;
 
 inline static bool startsWith(const char* pre, const char* str)
 {


### PR DESCRIPTION
suggest to add a functionality to set the custom TSAT directly via an edit popup of a suitable aircraft