### PR TITLE
Fix lnt-integer-float-division

### DIFF
--- a/CDMSingle.cpp
+++ b/CDMSingle.cpp
@@ -2250,7 +2250,7 @@ void CDM::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int Ite
 											//CAD check
 											if (CADapplies) {
 												if (myCad.airport != "xxxx") {
-													double seperationCAD = 60 / myCad.rate;
+													double seperationCAD = 60.0 / myCad.rate;
 													for (int z = 0; z < slotList.size(); z++)
 													{
 														string destFound = FlightPlanSelect(slotList[z].callsign.c_str()).GetFlightPlanData().GetDestination();
@@ -3972,10 +3972,10 @@ bool CDM::getRateFromUrl(string url) {
 							}
 						}
 						//Increase time according the rate change
-						slotList[z].tsat = calculateTime(slotList[z].tsat, (60 / stoi(r.rates[myPos])));
-						slotList[z].ttot = calculateTime(slotList[z].ttot, (60 / stoi(r.rates[myPos])));
+						slotList[z].tsat = calculateTime(slotList[z].tsat, (60.0 / stoi(r.rates[myPos])));
+						slotList[z].ttot = calculateTime(slotList[z].ttot, (60.0 / stoi(r.rates[myPos])));
 						if (slotList[z].hasCtot) {
-							slotList[z].ctot = calculateTime(slotList[z].ctot, (60 / stoi(r.rates[myPos])));
+							slotList[z].ctot = calculateTime(slotList[z].ctot, (60.0 / stoi(r.rates[myPos])));
 						}
 					}
 				}
@@ -4081,10 +4081,10 @@ bool CDM::getRate() {
 							}
 						}
 						//Increase time according the rate change
-						slotList[z].tsat = calculateTime(slotList[z].tsat, (60 / stoi(r.rates[myPos])));
-						slotList[z].ttot = calculateTime(slotList[z].ttot, (60 / stoi(r.rates[myPos])));
+						slotList[z].tsat = calculateTime(slotList[z].tsat, (60.0 / stoi(r.rates[myPos])));
+						slotList[z].ttot = calculateTime(slotList[z].ttot, (60.0 / stoi(r.rates[myPos])));
 						if (slotList[z].hasCtot) {
-							slotList[z].ctot = calculateTime(slotList[z].ctot, (60 / stoi(r.rates[myPos])));
+							slotList[z].ctot = calculateTime(slotList[z].ctot, (60.0 / stoi(r.rates[myPos])));
 						}
 					}
 				}
@@ -4549,7 +4549,7 @@ void CDM::refreshTimes(CFlightPlan FlightPlan, string callsign, string EOBT, str
 					//CAD check
 					if (CADapplies) {
 						if (myCad.airport != "xxxx") {
-							double seperationCAD = 60 / myCad.rate;
+							double seperationCAD = 60.0 / myCad.rate;
 							for (int z = 0; z < slotList.size(); z++)
 							{
 								string destFound = FlightPlanSelect(slotList[z].callsign.c_str()).GetFlightPlanData().GetDestination();
@@ -5433,7 +5433,7 @@ void CDM::getFlowData() {
 				if (typeMeasure.find("minimum_departure_interval") != std::string::npos) {
 					string valueMeasureString = fastWriter.write(measures[i]["measure"]["value"]);
 					if (isNumber(valueMeasureString)) {
-						valueMeasure = stoi(valueMeasureString) / 60;
+						valueMeasure = stoi(valueMeasureString) / 60.0;
 					}
 				}
 				//Get Filters


### PR DESCRIPTION
This fixes a big problem, when calculating times based on Capacity Availability Document values. 

The method `CDM::calculateTime(string timeString, double minsToAdd)` expects value _minsToAdd_ as double - an hour-rate given as minute separation, but it will always receive a rounded integer written as a double.

Example:
```
@@ -2250,7 +2250,7 @@ void CDM::OnGetTagItem()
double seperationCAD = 60 / myCad.rate;
double seperationCAD = 60 / 26;

Should: seperationCAD = 2.3077
Is:     seperationCAD = 2.0000
```

26 is the hour-rate of inbound-flights to London-Gatwick (EGKK). That should be one aircraft every 2.3 minutes. Instead, due to roundings in these calculations, the system calculates with the value of one aircraft every 2.0 minutes. Meaning 4 more, than actually possible (26 v 30).

See: [Microsoft - lnt-integer-float-division](https://learn.microsoft.com/en-us/cpp/ide/lnt-integer-float-division?view=msvc-170&f1url=%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(lnt-integer-float-division)%26rd%3Dtrue)
