### PR TITLE
Fix CURL problems

### DIFF
--- a/CDMSingle.cpp
+++ b/CDMSingle.cpp
@@ -5346,14 +5346,14 @@ void CDM::checkFlowStatus(Plane plane) {
 
 string CDM::getCidByCallsign(string callsign) {
 	CURL* curl;
-	CURLcode res;
+	CURLcode result;
 	std::string readBuffer;
 	curl = curl_easy_init();
 	if (curl) {
 		curl_easy_setopt(curl, CURLOPT_URL, "https://data.vatsim.net/v3/vatsim-data.json");
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
-		res = curl_easy_perform(curl);
+		result = curl_easy_perform(curl);
 		curl_easy_cleanup(curl);
 	}
 	Json::Reader reader;
@@ -5378,7 +5378,7 @@ void CDM::getFlowData() {
 	if (!flowRestrictionsUrl.empty()) {
 		vector<Flow> flowDataTemp;
 		CURL* curl;
-		CURLcode res;
+		CURLcode result;
 		std::string readBuffer;
 		long responseCode;
 		curl = curl_easy_init();
@@ -5387,12 +5387,12 @@ void CDM::getFlowData() {
 			curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 			curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 			curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
-			res = curl_easy_perform(curl);
+			result = curl_easy_perform(curl);
 			curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
 			curl_easy_cleanup(curl);
 		}
 
-		if (responseCode == 404 || CURLE_OPERATION_TIMEDOUT == res){
+		if (responseCode == 404 || CURLE_OPERATION_TIMEDOUT == result){
 			// handle error 404
 			sendMessage("UNABLE TO LOAD FlowRestrictions URL...");
 		}
@@ -5553,7 +5553,7 @@ bool CDM::getCtotsFromUrl(string code)
 	evCtots.clear();
 	string vatcanUrl = code;
 	CURL* curl;
-	CURLcode res;
+	CURLcode result;
 	std::string readBuffer;
 	long responseCode;
 	curl = curl_easy_init();
@@ -5562,12 +5562,12 @@ bool CDM::getCtotsFromUrl(string code)
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
-		res = curl_easy_perform(curl);
+		result = curl_easy_perform(curl);
 		curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
 		curl_easy_cleanup(curl);
 	}
 
-	if (responseCode == 404 || CURLE_OPERATION_TIMEDOUT == res) {
+	if (responseCode == 404 || CURLE_OPERATION_TIMEDOUT == result) {
 		// handle error 404
 		sendMessage("UNABLE TO LOAD CTOTs FROM VATCAN...");
 	}

--- a/CDMSingle.cpp
+++ b/CDMSingle.cpp
@@ -3866,7 +3866,7 @@ bool CDM::getRateFromUrl(string url) {
 	long responseCode;
 	curl = curl_easy_init();
 	if (curl) {
-		curl_easy_setopt(curl, CURLOPT_URL, url);
+		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
@@ -5383,7 +5383,7 @@ void CDM::getFlowData() {
 		long responseCode;
 		curl = curl_easy_init();
 		if (curl) {
-			curl_easy_setopt(curl, CURLOPT_URL, flowRestrictionsUrl);
+			curl_easy_setopt(curl, CURLOPT_URL, flowRestrictionsUrl.c_str());
 			curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 			curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 			curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
@@ -5558,7 +5558,7 @@ bool CDM::getCtotsFromUrl(string code)
 	long responseCode;
 	curl = curl_easy_init();
 	if (curl) {
-		curl_easy_setopt(curl, CURLOPT_URL, vatcanUrl);
+		curl_easy_setopt(curl, CURLOPT_URL, vatcanUrl.c_str());
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
@@ -5592,7 +5592,7 @@ bool CDM::getTaxiZonesFromUrl(string url) {
 	long responseCode;
 	curl = curl_easy_init();
 	if (curl) {
-		curl_easy_setopt(curl, CURLOPT_URL, url);
+		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
@@ -5642,7 +5642,7 @@ void CDM::getCADvalues() {
 	long responseCode;
 	curl = curl_easy_init();
 	if (curl) {
-		curl_easy_setopt(curl, CURLOPT_URL, cadUrl);
+		curl_easy_setopt(curl, CURLOPT_URL, cadUrl.c_str());
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
@@ -5698,7 +5698,7 @@ vector<CAD> CDM::returnCADvalues(string url)
 	long responseCode;
 	curl = curl_easy_init();
 	if (curl) {
-		curl_easy_setopt(curl, CURLOPT_URL, url);
+		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);

--- a/CDMSingle.cpp
+++ b/CDMSingle.cpp
@@ -3861,9 +3861,9 @@ static size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* use
 bool CDM::getRateFromUrl(string url) {
 	vector<Rate> myRates;
 	CURL* curl;
-	CURLcode result;
+	CURLcode result = CURLE_FAILED_INIT;
 	string readBuffer;
-	long responseCode;
+	long responseCode = 0;
 	curl = curl_easy_init();
 	if (curl) {
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
@@ -4938,7 +4938,7 @@ string CDM::calculateTime(string timeString, double minsToAdd) {
 	int hours = stoi(timeString.substr(0, 2));
 	int mins = stoi(timeString.substr(2, 2));
 	int sec = stoi(timeString.substr(4, timeString.length() - 1));
-
+	
 	int movTime = minsToAdd * 60;
 	while (movTime > 0) {
 		sec += 1;
@@ -5346,7 +5346,7 @@ void CDM::checkFlowStatus(Plane plane) {
 
 string CDM::getCidByCallsign(string callsign) {
 	CURL* curl;
-	CURLcode result;
+	CURLcode result = CURLE_FAILED_INIT;
 	std::string readBuffer;
 	curl = curl_easy_init();
 	if (curl) {
@@ -5379,9 +5379,9 @@ void CDM::getFlowData() {
 	if (!flowRestrictionsUrl.empty()) {
 		vector<Flow> flowDataTemp;
 		CURL* curl;
-		CURLcode result;
+		CURLcode result = CURLE_FAILED_INIT;
 		std::string readBuffer;
-		long responseCode;
+		long responseCode = 0;
 		curl = curl_easy_init();
 		if (curl) {
 			curl_easy_setopt(curl, CURLOPT_URL, flowRestrictionsUrl.c_str());
@@ -5530,7 +5530,7 @@ void CDM::upload(string fileName, string airport)
 
 int CDM::GetVersion() {
 	CURL* curl;
-	CURLcode result;
+	CURLcode result = CURLE_FAILED_INIT;
 	std::string readBuffer = "";
 	curl = curl_easy_init();
 	if (curl) {
@@ -5555,9 +5555,9 @@ bool CDM::getCtotsFromUrl(string code)
 	evCtots.clear();
 	string vatcanUrl = code;
 	CURL* curl;
-	CURLcode result;
+	CURLcode result = CURLE_FAILED_INIT;
 	std::string readBuffer;
-	long responseCode;
+	long responseCode = 0;
 	curl = curl_easy_init();
 	if (curl) {
 		curl_easy_setopt(curl, CURLOPT_URL, vatcanUrl.c_str());
@@ -5589,9 +5589,9 @@ bool CDM::getCtotsFromUrl(string code)
 
 bool CDM::getTaxiZonesFromUrl(string url) {
 	CURL* curl;
-	CURLcode result;
+	CURLcode result = CURLE_FAILED_INIT;
 	string readBuffer;
-	long responseCode;
+	long responseCode = 0;
 	curl = curl_easy_init();
 	if (curl) {
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
@@ -5639,9 +5639,9 @@ void CDM::getCADvalues() {
 	}
 
 	CURL* curl;
-	CURLcode result;
+	CURLcode result = CURLE_FAILED_INIT;
 	string readBuffer;
-	long responseCode;
+	long responseCode = 0;
 	curl = curl_easy_init();
 	if (curl) {
 		curl_easy_setopt(curl, CURLOPT_URL, cadUrl.c_str());
@@ -5695,9 +5695,9 @@ vector<CAD> CDM::returnCADvalues(string url)
 	}
 
 	CURL* curl;
-	CURLcode result;
+	CURLcode result = CURLE_FAILED_INIT;
 	string readBuffer;
-	long responseCode;
+	long responseCode = 0;
 	curl = curl_easy_init();
 	if (curl) {
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());

--- a/CDMSingle.cpp
+++ b/CDMSingle.cpp
@@ -3875,7 +3875,7 @@ bool CDM::getRateFromUrl(string url) {
 		curl_easy_cleanup(curl);
 	}
 
-	if (responseCode == 404 || CURLE_OPERATION_TIMEDOUT == result) {
+	if (responseCode == 404 || CURLE_OK != result) {
 		// handle error 404
 		sendMessage("UNABLE TO LOAD TaxiZones URL...");
 	}
@@ -5392,7 +5392,7 @@ void CDM::getFlowData() {
 			curl_easy_cleanup(curl);
 		}
 
-		if (responseCode == 404 || CURLE_OPERATION_TIMEDOUT == result){
+		if (responseCode == 404 || CURLE_OK != result){
 			// handle error 404
 			sendMessage("UNABLE TO LOAD FlowRestrictions URL...");
 		}
@@ -5567,7 +5567,7 @@ bool CDM::getCtotsFromUrl(string code)
 		curl_easy_cleanup(curl);
 	}
 
-	if (responseCode == 404 || CURLE_OPERATION_TIMEDOUT == result) {
+	if (responseCode == 404 || CURLE_OK != result) {
 		// handle error 404
 		sendMessage("UNABLE TO LOAD CTOTs FROM VATCAN...");
 	}
@@ -5601,7 +5601,7 @@ bool CDM::getTaxiZonesFromUrl(string url) {
 		curl_easy_cleanup(curl);
 	}
 
-	if (responseCode == 404 || CURLE_OPERATION_TIMEDOUT == result) {
+	if (responseCode == 404 || CURLE_OK != result) {
 		// handle error 404
 		sendMessage("UNABLE TO LOAD TaxiZones URL...");
 	}
@@ -5649,9 +5649,9 @@ void CDM::getCADvalues() {
 		result = curl_easy_perform(curl);
 		curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
 		curl_easy_cleanup(curl);
-	}
+	} 
 
-	if (responseCode == 404 || CURLE_OPERATION_TIMEDOUT == result) {
+	if (responseCode == 404 || CURLE_OK != result) {
 		// handle error 404
 		sendMessage("UNABLE TO LOAD CAD URL...");
 	}
@@ -5707,7 +5707,7 @@ vector<CAD> CDM::returnCADvalues(string url)
 		curl_easy_cleanup(curl);
 	}
 
-	if (responseCode == 404 || CURLE_OPERATION_TIMEDOUT == result) {
+	if (responseCode == 404 || CURLE_OK != result) {
 		// handle error 404
 		sendMessage("UNABLE TO LOAD CAD URL...");
 	}

--- a/CDMSingle.cpp
+++ b/CDMSingle.cpp
@@ -5353,6 +5353,7 @@ string CDM::getCidByCallsign(string callsign) {
 		curl_easy_setopt(curl, CURLOPT_URL, "https://data.vatsim.net/v3/vatsim-data.json");
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
+		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
 		result = curl_easy_perform(curl);
 		curl_easy_cleanup(curl);
 	}
@@ -5536,6 +5537,7 @@ int CDM::GetVersion() {
 		curl_easy_setopt(curl, CURLOPT_URL, "https://raw.githubusercontent.com/rpuig2001/CDM/master/version.txt");
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
+		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
 		result = curl_easy_perform(curl);
 		curl_easy_cleanup(curl);
 	}


### PR DESCRIPTION
- Just setting the CURLcode variable names all to _"result"_ for beauty.
- CURLOPT_TIMEOUT added for CDM Version & Vatsim Data
- Fixed CURL_URL_MALFORMAT on six occursions. CURL expects a char*, gets a std::string - Actually fixes all CURL problems for me
-  CURL response-check only looked for 404 or CURLE_OPERATION_TIMEDOUT. It didn't catch the above mentioned MALFORMAT or one, that occured for me: COULDNT_RESOLVE_HOST. Now it catches all of them:
-- _(CURLE_OK (0): The request was successful.)_
-- CURLE_UNSUPPORTED_PROTOCOL (1): The URL you provided uses an unsupported protocol.
-- CURLE_FAILED_INIT (2): libcurl failed to initialize.
-- CURLE_URL_MALFORMAT (3): The URL is not properly formatted.
-- CURLE_COULDNT_RESOLVE_PROXY (5): Could not resolve the proxy hostname.
-- CURLE_COULDNT_RESOLVE_HOST (6): Could not resolve the remote hostname.
-- CURLE_COULDNT_CONNECT (7): Could not connect to the remote host.
-- CURLE_OPERATION_TIMEDOUT (28): The request timed out.
-- CURLE_SSL_CONNECT_ERROR (35): A problem occurred during SSL connection.
- Fixed crash, if object curl doesn't initialize for any reason

You might want to consider sharing the fail reason with the user
```
sendMessage("UNABLE TO LOAD CAD URL (" + string(curl_easy_strerror(result)) + ")");
```
or something like that
