### PR TITLE
Cleanup - C4715 OnCompileCommand: not all control paths return a value

### DIFF
--- a/CDMSingle.cpp
+++ b/CDMSingle.cpp
@@ -7315,6 +7315,7 @@ bool CDM::OnCompileCommand(const char* sCommandLine) {
 
 		return true;
 	}
+	return false;
 }
 
 void CDM::OnTimer(int Counter) {


### PR DESCRIPTION
Added default return for OnCompileCommand.